### PR TITLE
Add dataset report

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -12,3 +12,13 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/dataset.csv
+
+  generate_dataset_report:
+    run: >
+      dataset-report:v0.0.26
+        --input-files output/dataset.csv
+        --output-dir output
+    needs: [generate_dataset]
+    outputs:
+      moderately_sensitive:
+        dataset_report: output/dataset.html


### PR DESCRIPTION
This adds the reusable action https://github.com/opensafely-actions/dataset-report to explore the data in order to compare  results from the cohort-extractor study https://github.com/opensafely/CIS-pop-validation with this ehrQL study.