### PR TITLE
Investigate population differences

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -243,3 +243,21 @@ dataset.set_population(
     & set_not_care_home
     & set_msoa_not_null
 )
+
+
+# New temporary dataset to capture the individual components of the population
+# definition for comparison with cohortextractor
+new_dataset = Dataset()
+new_dataset.set_population(patients.exists_for_patient())
+
+new_dataset.registered = set_registered
+new_dataset.has_died = has_died
+new_dataset.care_home_tpp = care_home_tpp
+new_dataset.care_home_code = care_home_code
+new_dataset.age = dataset.age
+new_dataset.sex = dataset.sex
+new_dataset.msoa = dataset.msoa
+new_dataset.included = dataset.population
+
+# Overwrite the origianl dataset with our temporary one
+dataset = new_dataset

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -39,22 +39,6 @@ study = StudyDefinition(
   # This line defines the study population
   population=patients.all(),
 
-  included=patients.satisfying(
-    """
-      registered
-      AND
-      age >= 2 AND age <=120
-      AND
-      sex = "M" OR sex = "F" 
-      AND
-      NOT has_died
-      AND 
-      NOT ((care_home_tpp="care_or_nursing_home") OR (care_home_code))
-      AND 
-      msoa
-    """,
-  ),
-    
   # we define baseline variables on the day _before_ the study date
   registered=patients.registered_as_of(
     "index_date",
@@ -222,6 +206,22 @@ study = StudyDefinition(
     },
   ),    
   
+  included=patients.satisfying(
+    """
+      registered
+      AND
+      age >= 2 AND age <=120
+      AND
+      sex = "M" OR sex = "F" 
+      AND
+      NOT has_died
+      AND 
+      NOT ((care_home_tpp="care_or_nursing_home") OR (care_home_code))
+      AND 
+      msoa
+    """,
+  ),
+    
   #  # stp is an NHS administration region based on geography
   #  stp=patients.registered_practice_as_of(
   #    "index_date",

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -53,40 +53,38 @@ study = StudyDefinition(
       AND 
       msoa
     """,
-    
-    # we define baseline variables on the day _before_ the study date
-    registered=patients.registered_as_of(
-      "index_date",
-    ),
-    has_died=patients.died_from_any_cause(
-      on_or_before="index_date",
-      returning="binary_flag",
-    ), 
-    
-    # patients in care or nursing homes according to patient address / residence type look up
-    care_home_tpp=patients.care_home_status_as_of(
-      "index_date",
-      categorised_as={
-          "care_or_nursing_home": "IsPotentialCareHome",
-          "": "DEFAULT",  # use empty string
-      },
-      return_expectations={
-          "category": {"ratios": {"care_or_nursing_home": 0.05, "": 0.95 }, },
-          "incidence": 1,
-      },
-    ),
-
-    # Patients in long-stay nursing and residential care
-    care_home_code=patients.with_these_clinical_events(
-      codelists_cohortextractor.carehome,
-      on_or_before="index_date",
-      returning="binary_flag",
-      return_expectations={"incidence": 0.01},
-    ),
-    
-    startdate = patients.fixed_value(start_date),
-    enddate = patients.fixed_value(end_date),
   ),
+    
+  # we define baseline variables on the day _before_ the study date
+  registered=patients.registered_as_of(
+    "index_date",
+  ),
+  has_died=patients.died_from_any_cause(
+    on_or_before="index_date",
+    returning="binary_flag",
+  ), 
+  
+  # patients in care or nursing homes according to patient address / residence type look up
+  care_home_tpp=patients.care_home_status_as_of(
+    "index_date",
+    categorised_as={
+        "care_or_nursing_home": "IsPotentialCareHome",
+        "": "DEFAULT",  # use empty string
+    },
+    return_expectations={
+        "category": {"ratios": {"care_or_nursing_home": 0.05, "": 0.95 }, },
+        "incidence": 1,
+    },
+  ),
+
+  # Patients in long-stay nursing and residential care
+  care_home_code=patients.with_these_clinical_events(
+    codelists_cohortextractor.carehome,
+    on_or_before="index_date",
+    returning="binary_flag",
+    return_expectations={"incidence": 0.01},
+  ),
+    
   
   
   ###############################################################################

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -37,7 +37,9 @@ study = StudyDefinition(
   index_date = start_date,
   
   # This line defines the study population
-  population=patients.satisfying(
+  population=patients.all(),
+
+  included=patients.satisfying(
     """
       registered
       AND

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -222,297 +222,297 @@ study = StudyDefinition(
     },
   ),    
   
-  # stp is an NHS administration region based on geography
-  stp=patients.registered_practice_as_of(
-    "index_date",
-    returning="stp_code",
-    return_expectations={
-      "rate": "universal",
-      "category": {
-        "ratios": {
-          "STP1": 0.1,
-          "STP2": 0.1,
-          "STP3": 0.1,
-          "STP4": 0.1,
-          "STP5": 0.1,
-          "STP6": 0.1,
-          "STP7": 0.1,
-          "STP8": 0.1,
-          "STP9": 0.1,
-          "STP10": 0.1,
-        }
-      },
-    },
-  ),
-  
-  # NHS administrative region
-  # FIXME can we get an equivalent using patient postcode not GP address?
-  region=patients.registered_practice_as_of(
-    "index_date",
-    returning="nuts1_region_name",
-    return_expectations={
-      "rate": "universal",
-      "category": {
-        "ratios": {
-          "North East": 0.1,
-          "North West": 0.1,
-          "Yorkshire and The Humber": 0.2,
-          "East Midlands": 0.1,
-          "West Midlands": 0.1,
-          "East": 0.1,
-          "London": 0.1,
-          "South East": 0.1,
-          "South West": 0.1
-          #"" : 0.01
-        },
-      },
-    },
-  ),
-  
-  ## IMD - quintile
-  # imd=patients.address_as_of(
-  #   "index_date",
-  #   returning="index_of_multiple_deprivation",
-  #   round_to_nearest=100,
-  #   return_expectations={
-  #     "category": {"ratios": {c: 1/320 for c in range(100, 32100, 100)}}
-  #   }
-  # ),
-  
-  # currently in hospital on index date
-  # inhospital = patients.satisfying(
-  # 
-  #   "discharged_date > index_date",
-  #   
-  #   discharged_date=patients.admitted_to_hospital(
-  #     returning="date_discharged",
-  #     on_or_before="index_date", #FIXME -- need to decide whether to include admissions discharged on the same day as booster dose or not
-  #     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
-  #     # see https://docs.opensafely.org/study-def-variables/#sus for more info
-  #     with_patient_classification = ["1"], # ordinary admissions only
-  #     #with_discharge_destination = codelists_cohortextractor.discharged_to_hospital
-  #     date_format="YYYY-MM-DD",
-  #     find_last_match_in_period=True,
-  #   ), 
-  # ),
-  # 
+  #  # stp is an NHS administration region based on geography
+  #  stp=patients.registered_practice_as_of(
+  #    "index_date",
+  #    returning="stp_code",
+  #    return_expectations={
+  #      "rate": "universal",
+  #      "category": {
+  #        "ratios": {
+  #          "STP1": 0.1,
+  #          "STP2": 0.1,
+  #          "STP3": 0.1,
+  #          "STP4": 0.1,
+  #          "STP5": 0.1,
+  #          "STP6": 0.1,
+  #          "STP7": 0.1,
+  #          "STP8": 0.1,
+  #          "STP9": 0.1,
+  #          "STP10": 0.1,
+  #        }
+  #      },
+  #    },
+  #  ),
+  #  
+  #  # NHS administrative region
+  #  # FIXME can we get an equivalent using patient postcode not GP address?
+  #  region=patients.registered_practice_as_of(
+  #    "index_date",
+  #    returning="nuts1_region_name",
+  #    return_expectations={
+  #      "rate": "universal",
+  #      "category": {
+  #        "ratios": {
+  #          "North East": 0.1,
+  #          "North West": 0.1,
+  #          "Yorkshire and The Humber": 0.2,
+  #          "East Midlands": 0.1,
+  #          "West Midlands": 0.1,
+  #          "East": 0.1,
+  #          "London": 0.1,
+  #          "South East": 0.1,
+  #          "South West": 0.1
+  #          #"" : 0.01
+  #        },
+  #      },
+  #    },
+  #  ),
+  #  
+  #  ## IMD - quintile
+  #  # imd=patients.address_as_of(
+  #  #   "index_date",
+  #  #   returning="index_of_multiple_deprivation",
+  #  #   round_to_nearest=100,
+  #  #   return_expectations={
+  #  #     "category": {"ratios": {c: 1/320 for c in range(100, 32100, 100)}}
+  #  #   }
+  #  # ),
+  #  
+  #  # currently in hospital on index date
+  #  # inhospital = patients.satisfying(
+  #  # 
+  #  #   "discharged_date > index_date",
+  #  #   
+  #  #   discharged_date=patients.admitted_to_hospital(
+  #  #     returning="date_discharged",
+  #  #     on_or_before="index_date", #FIXME -- need to decide whether to include admissions discharged on the same day as booster dose or not
+  #  #     # see https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
+  #  #     # see https://docs.opensafely.org/study-def-variables/#sus for more info
+  #  #     with_patient_classification = ["1"], # ordinary admissions only
+  #  #     #with_discharge_destination = codelists_cohortextractor.discharged_to_hospital
+  #  #     date_format="YYYY-MM-DD",
+  #  #     find_last_match_in_period=True,
+  #  #   ), 
+  #  # ),
+  #  # 
 
-  ############################################################
-  ## single-day events
-  ## "Did any event occur on this day?"
-  ############################################################
+  #  ############################################################
+  #  ## single-day events
+  #  ## "Did any event occur on this day?"
+  #  ############################################################
 
-  # positive covid test
-  postest_01=patients.with_test_result_in_sgss(
-      pathogen="SARS-CoV-2",
-      test_result="positive",
-      returning="binary_flag",
-      between=["index_date", "index_date"],
-      find_first_match_in_period=True,
-      restrict_to_earliest_specimen_date=False,
-  ),
-  
-  # positive sympomatic covid test
-  # postest_symptomatic_01=patients.satisfying(
-  #   """
-  #   postest_01 AND symptom_01="Y"
-  #   """,
-  # 
-  #   symptom_01 = patients.with_test_result_in_sgss(
-  #     pathogen="SARS-CoV-2",
-  #     test_result="positive",
-  #     returning="symptomatic",
-  #     between=["index_date", "index_date"],
-  #     find_first_match_in_period=True,
-  #     restrict_to_earliest_specimen_date=False,
-  #   ),
-  # ),
-  
-  # positive case identification
-  primary_care_covid_case_01=patients.with_these_clinical_events(
-    combine_codelists( # FIXME - ask Colm about new codelists
-      codelists_cohortextractor.covid_primary_care_code,
-      codelists_cohortextractor.covid_primary_care_positive_test,
-      codelists_cohortextractor.covid_primary_care_sequelae,
-    ),
-    returning="binary_flag",
-    date_format="YYYY-MM-DD",
-    between=["index_date", "index_date"],
-    find_first_match_in_period=True,
-  ),
-  
-  # emergency attendance for covid
-  covidemergency_01=patients.attended_emergency_care(
-    returning="binary_flag",
-    date_format="YYYY-MM-DD",
-    between=["index_date", "index_date"],
-    with_these_diagnoses = codelists_cohortextractor.covid_emergency,
-    find_first_match_in_period=True,
-  ),
-  
-  # covid admission
-  covidadmitted_01=patients.admitted_to_hospital(
-    returning="binary_flag",
-    with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
-    with_these_diagnoses=codelists_cohortextractor.covid_icd10,
-    between=["index_date", "index_date"],
-    find_first_match_in_period=True,
-  ),
-  
-  any_infection_or_disease_01=patients.satisfying(
-    """
-    postest_01
-    OR primary_care_covid_case_01
-    OR covidemergency_01
-    OR covidadmitted_01
-    """
-  ),
-  
-  
-  ############################################################
-  ## 14-day events
-  ## "Did any event occur within the last 14 days?"
-  ############################################################
+  #  # positive covid test
+  #  postest_01=patients.with_test_result_in_sgss(
+  #      pathogen="SARS-CoV-2",
+  #      test_result="positive",
+  #      returning="binary_flag",
+  #      between=["index_date", "index_date"],
+  #      find_first_match_in_period=True,
+  #      restrict_to_earliest_specimen_date=False,
+  #  ),
+  #  
+  #  # positive sympomatic covid test
+  #  # postest_symptomatic_01=patients.satisfying(
+  #  #   """
+  #  #   postest_01 AND symptom_01="Y"
+  #  #   """,
+  #  # 
+  #  #   symptom_01 = patients.with_test_result_in_sgss(
+  #  #     pathogen="SARS-CoV-2",
+  #  #     test_result="positive",
+  #  #     returning="symptomatic",
+  #  #     between=["index_date", "index_date"],
+  #  #     find_first_match_in_period=True,
+  #  #     restrict_to_earliest_specimen_date=False,
+  #  #   ),
+  #  # ),
+  #  
+  #  # positive case identification
+  #  primary_care_covid_case_01=patients.with_these_clinical_events(
+  #    combine_codelists( # FIXME - ask Colm about new codelists
+  #      codelists_cohortextractor.covid_primary_care_code,
+  #      codelists_cohortextractor.covid_primary_care_positive_test,
+  #      codelists_cohortextractor.covid_primary_care_sequelae,
+  #    ),
+  #    returning="binary_flag",
+  #    date_format="YYYY-MM-DD",
+  #    between=["index_date", "index_date"],
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  # emergency attendance for covid
+  #  covidemergency_01=patients.attended_emergency_care(
+  #    returning="binary_flag",
+  #    date_format="YYYY-MM-DD",
+  #    between=["index_date", "index_date"],
+  #    with_these_diagnoses = codelists_cohortextractor.covid_emergency,
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  # covid admission
+  #  covidadmitted_01=patients.admitted_to_hospital(
+  #    returning="binary_flag",
+  #    with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
+  #    with_these_diagnoses=codelists_cohortextractor.covid_icd10,
+  #    between=["index_date", "index_date"],
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  any_infection_or_disease_01=patients.satisfying(
+  #    """
+  #    postest_01
+  #    OR primary_care_covid_case_01
+  #    OR covidemergency_01
+  #    OR covidadmitted_01
+  #    """
+  #  ),
+  #  
+  #  
+  #  ############################################################
+  #  ## 14-day events
+  #  ## "Did any event occur within the last 14 days?"
+  #  ############################################################
 
-  # positive covid test
-  postest_14=patients.with_test_result_in_sgss(
-      pathogen="SARS-CoV-2",
-      test_result="positive",
-      returning="binary_flag",
-      between=["index_date - 13 days", "index_date"],
-      find_first_match_in_period=True,
-      restrict_to_earliest_specimen_date=False,
-  ),
-  
-  # positive sympomatic covid test
-  # FIXME: note this will not pick up a symptomatic test that occurred before a subsequent non-symptomatic test within the same period
-  # because we can only "return" symptomatic status, not filter on it
-  # postest_symptomatic_14=patients.satisfying(
-  #   """
-  #   postest_14 AND symptom_14="Y"
-  #   """,
-  # 
-  #   symptom_14 = patients.with_test_result_in_sgss(
-  #     pathogen="SARS-CoV-2",
-  #     test_result="positive",
-  #     returning="symptomatic",
-  #     between=["index_date - 13 days", "index_date"],
-  #     find_first_match_in_period=True,
-  #     restrict_to_earliest_specimen_date=False,
-  #   ),
-  # ),
-  
-  # Positive case identification
-  primary_care_covid_case_14=patients.with_these_clinical_events(
-    combine_codelists( # FIXME - ask Colm about new codelists
-      codelists_cohortextractor.covid_primary_care_code,
-      codelists_cohortextractor.covid_primary_care_positive_test,
-      codelists_cohortextractor.covid_primary_care_sequelae,
-    ),
-    returning="binary_flag",
-    date_format="YYYY-MM-DD",
-    between=["index_date - 13 days", "index_date"],
-    find_first_match_in_period=True,
-  ),
-  
-  # emergency attendance for covid
-  covidemergency_14=patients.attended_emergency_care(
-    returning="binary_flag",
-    date_format="YYYY-MM-DD",
-    between=["index_date - 13 days", "index_date"],
-    with_these_diagnoses = codelists_cohortextractor.covid_emergency,
-    find_first_match_in_period=True,
-  ),
+  #  # positive covid test
+  #  postest_14=patients.with_test_result_in_sgss(
+  #      pathogen="SARS-CoV-2",
+  #      test_result="positive",
+  #      returning="binary_flag",
+  #      between=["index_date - 13 days", "index_date"],
+  #      find_first_match_in_period=True,
+  #      restrict_to_earliest_specimen_date=False,
+  #  ),
+  #  
+  #  # positive sympomatic covid test
+  #  # FIXME: note this will not pick up a symptomatic test that occurred before a subsequent non-symptomatic test within the same period
+  #  # because we can only "return" symptomatic status, not filter on it
+  #  # postest_symptomatic_14=patients.satisfying(
+  #  #   """
+  #  #   postest_14 AND symptom_14="Y"
+  #  #   """,
+  #  # 
+  #  #   symptom_14 = patients.with_test_result_in_sgss(
+  #  #     pathogen="SARS-CoV-2",
+  #  #     test_result="positive",
+  #  #     returning="symptomatic",
+  #  #     between=["index_date - 13 days", "index_date"],
+  #  #     find_first_match_in_period=True,
+  #  #     restrict_to_earliest_specimen_date=False,
+  #  #   ),
+  #  # ),
+  #  
+  #  # Positive case identification
+  #  primary_care_covid_case_14=patients.with_these_clinical_events(
+  #    combine_codelists( # FIXME - ask Colm about new codelists
+  #      codelists_cohortextractor.covid_primary_care_code,
+  #      codelists_cohortextractor.covid_primary_care_positive_test,
+  #      codelists_cohortextractor.covid_primary_care_sequelae,
+  #    ),
+  #    returning="binary_flag",
+  #    date_format="YYYY-MM-DD",
+  #    between=["index_date - 13 days", "index_date"],
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  # emergency attendance for covid
+  #  covidemergency_14=patients.attended_emergency_care(
+  #    returning="binary_flag",
+  #    date_format="YYYY-MM-DD",
+  #    between=["index_date - 13 days", "index_date"],
+  #    with_these_diagnoses = codelists_cohortextractor.covid_emergency,
+  #    find_first_match_in_period=True,
+  #  ),
 
-  # covid admission
-  covidadmitted_14=patients.admitted_to_hospital(
-    returning="binary_flag",
-    with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
-    with_these_diagnoses=codelists_cohortextractor.covid_icd10,
-    between=["index_date - 13 days", "index_date"],
-    find_first_match_in_period=True,
-  ),
-  
-  any_infection_or_disease_14=patients.satisfying(
-    """
-    postest_14
-    OR primary_care_covid_case_14
-    OR covidemergency_14
-    OR covidadmitted_14
-    """
-  ),
+  #  # covid admission
+  #  covidadmitted_14=patients.admitted_to_hospital(
+  #    returning="binary_flag",
+  #    with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
+  #    with_these_diagnoses=codelists_cohortextractor.covid_icd10,
+  #    between=["index_date - 13 days", "index_date"],
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  any_infection_or_disease_14=patients.satisfying(
+  #    """
+  #    postest_14
+  #    OR primary_care_covid_case_14
+  #    OR covidemergency_14
+  #    OR covidadmitted_14
+  #    """
+  #  ),
 
-  ############################################################
-  ## ever-day events
-  ## "Did any event occur any time up to and including this day?"
-  ############################################################
+  #  ############################################################
+  #  ## ever-day events
+  #  ## "Did any event occur any time up to and including this day?"
+  #  ############################################################
 
-  # positive covid test
-  postest_ever=patients.with_test_result_in_sgss(
-      pathogen="SARS-CoV-2",
-      test_result="positive",
-      returning="binary_flag",
-      on_or_before="index_date",
-      find_first_match_in_period=True,
-      restrict_to_earliest_specimen_date=False,
-  ),
-  
-  # positive symptomatic covid test
-  # FIXME: note this will not pick up a symptomatic test that occurred before a subsequent non-symptomatic test within the same period
-  # because we can only "return" symptomatic status, not filter on it
-  # postest_symptomatic_ever=patients.satisfying(
-  #   """
-  #   postest_ever AND symptom_ever="Y"
-  #   """,
-  #   symptom_ever = patients.with_test_result_in_sgss(
-  #     pathogen="SARS-CoV-2",
-  #     test_result="positive",
-  #     returning="symptomatic",
-  #     on_or_before="index_date",
-  #     find_first_match_in_period=True,
-  #     restrict_to_earliest_specimen_date=False,
-  #   ),
-  # ),
-  # 
-  
-  # positive case identification
-  primary_care_covid_case_ever=patients.with_these_clinical_events(
-    combine_codelists( # FIXME - ask Colm about new codelists
-      codelists_cohortextractor.covid_primary_care_code,
-      codelists_cohortextractor.covid_primary_care_positive_test,
-      codelists_cohortextractor.covid_primary_care_sequelae,
-    ),
-    returning="binary_flag",
-    on_or_before="index_date",
-    find_first_match_in_period=True,
-  ),
-  
-  # emergency attendance for covid
-  covidemergency_ever=patients.attended_emergency_care(
-    returning="binary_flag",
-    on_or_before="index_date",
-    with_these_diagnoses = codelists_cohortextractor.covid_emergency,
-    find_first_match_in_period=True,
-  ),
-  
-  # covid admission
-  covidadmitted_ever=patients.admitted_to_hospital(
-    returning="binary_flag",
-    with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
-    with_these_diagnoses=codelists_cohortextractor.covid_icd10,
-    on_or_before="index_date",
-    find_first_match_in_period=True,
-  ),
-  
-  # 
-  any_infection_or_disease_ever=patients.satisfying(
-    """
-    postest_ever
-    OR primary_care_covid_case_ever
-    OR covidemergency_ever
-    OR covidadmitted_ever
-    """
-  )
+  #  # positive covid test
+  #  postest_ever=patients.with_test_result_in_sgss(
+  #      pathogen="SARS-CoV-2",
+  #      test_result="positive",
+  #      returning="binary_flag",
+  #      on_or_before="index_date",
+  #      find_first_match_in_period=True,
+  #      restrict_to_earliest_specimen_date=False,
+  #  ),
+  #  
+  #  # positive symptomatic covid test
+  #  # FIXME: note this will not pick up a symptomatic test that occurred before a subsequent non-symptomatic test within the same period
+  #  # because we can only "return" symptomatic status, not filter on it
+  #  # postest_symptomatic_ever=patients.satisfying(
+  #  #   """
+  #  #   postest_ever AND symptom_ever="Y"
+  #  #   """,
+  #  #   symptom_ever = patients.with_test_result_in_sgss(
+  #  #     pathogen="SARS-CoV-2",
+  #  #     test_result="positive",
+  #  #     returning="symptomatic",
+  #  #     on_or_before="index_date",
+  #  #     find_first_match_in_period=True,
+  #  #     restrict_to_earliest_specimen_date=False,
+  #  #   ),
+  #  # ),
+  #  # 
+  #  
+  #  # positive case identification
+  #  primary_care_covid_case_ever=patients.with_these_clinical_events(
+  #    combine_codelists( # FIXME - ask Colm about new codelists
+  #      codelists_cohortextractor.covid_primary_care_code,
+  #      codelists_cohortextractor.covid_primary_care_positive_test,
+  #      codelists_cohortextractor.covid_primary_care_sequelae,
+  #    ),
+  #    returning="binary_flag",
+  #    on_or_before="index_date",
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  # emergency attendance for covid
+  #  covidemergency_ever=patients.attended_emergency_care(
+  #    returning="binary_flag",
+  #    on_or_before="index_date",
+  #    with_these_diagnoses = codelists_cohortextractor.covid_emergency,
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  # covid admission
+  #  covidadmitted_ever=patients.admitted_to_hospital(
+  #    returning="binary_flag",
+  #    with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"],
+  #    with_these_diagnoses=codelists_cohortextractor.covid_icd10,
+  #    on_or_before="index_date",
+  #    find_first_match_in_period=True,
+  #  ),
+  #  
+  #  # 
+  #  any_infection_or_disease_ever=patients.satisfying(
+  #    """
+  #    postest_ever
+  #    OR primary_care_covid_case_ever
+  #    OR covidemergency_ever
+  #    OR covidadmitted_ever
+  #    """
+  #  )
   
 )
 

--- a/project.yaml
+++ b/project.yaml
@@ -26,13 +26,13 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/dataset_ehrql_2022-09-25.csv
-
-  calculate_dataset_diff:
-    run: >
-      r:latest analysis/dataset_diff.R
-    needs:
-      - generate_dataset_cohortextractor
-      - generate_dataset_ehrql
-    outputs:
-      moderately_sensitive:
-        cohort: output/diff/dataset_diff_summary.csv
+ 
+  # calculate_dataset_diff:
+  #   run: >
+  #     r:latest analysis/dataset_diff.R
+  #   needs:
+  #     - generate_dataset_cohortextractor
+  #     - generate_dataset_ehrql
+  #   outputs:
+  #     moderately_sensitive:
+  #       cohort: output/diff/dataset_diff_summary.csv


### PR DESCRIPTION
This makes some temporary changes to the dataset/study definitions so that we can better compare why the extracted populations are not identical between Data Builder and Cohort Extractor.

In both cases, we set the population to be "everyone in the patients table", add a variable `included` to flag whether a patient meets the original population definition and then create individual variables for the logical components of the population definition.