### PR TITLE
Add feedback from initial code review

### DIFF
--- a/analysis/codelists_cohortextractor.py
+++ b/analysis/codelists_cohortextractor.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 from cohortextractor import (codelist, codelist_from_csv, combine_codelists)
+
+CODELIST_DIR = Path("codelists")
 
 
 covid_icd10 = codelist_from_csv(
-    "codelists/opensafely-covid-identification.csv",
+    CODELIST_DIR / "opensafely-covid-identification.csv",
     system="icd10",
     column="icd10_code",
 )
@@ -14,19 +18,19 @@ covid_emergency = codelist(
 
 
 covid_primary_care_positive_test = codelist_from_csv(
-    "codelists/opensafely-covid-identification-in-primary-care-probable-covid-positive-test.csv",
+    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-positive-test.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 covid_primary_care_code = codelist_from_csv(
-    "codelists/opensafely-covid-identification-in-primary-care-probable-covid-clinical-code.csv",
+    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-clinical-code.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 covid_primary_care_sequelae = codelist_from_csv(
-    "codelists/opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
+    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
     system="ctv3",
     column="CTV3ID",
 )
@@ -71,13 +75,13 @@ covid_primary_care_probable_combined = combine_codelists(
 
 
 ethnicity = codelist_from_csv(
-    "codelists/opensafely-ethnicity.csv",
+    CODELIST_DIR / "opensafely-ethnicity.csv",
     system="ctv3",
     column="Code",
     category_column="Grouping_6",
 )
 ethnicity_16 = codelist_from_csv(
-    "codelists/opensafely-ethnicity.csv",
+    CODELIST_DIR / "opensafely-ethnicity.csv",
     system="ctv3",
     column="Code",
     category_column="Grouping_16",
@@ -90,7 +94,7 @@ ethnicity_16 = codelist_from_csv(
 
 # Patients in long-stay nursing and residential care
 carehome = codelist_from_csv(
-    "codelists/primis-covid19-vacc-uptake-longres.csv", 
+    CODELIST_DIR / "primis-covid19-vacc-uptake-longres.csv", 
     system="snomed", 
     column="code",
 )

--- a/analysis/codelists_ehrql.py
+++ b/analysis/codelists_ehrql.py
@@ -25,19 +25,22 @@ covid_emergency = codelist(
 )
 
 covid_primary_care_positive_test = codelist_from_csv(
-    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-positive-test.csv",
+    CODELIST_DIR
+    / "opensafely-covid-identification-in-primary-care-probable-covid-positive-test.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 covid_primary_care_code = codelist_from_csv(
-    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-clinical-code.csv",
+    CODELIST_DIR
+    / "opensafely-covid-identification-in-primary-care-probable-covid-clinical-code.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 covid_primary_care_sequelae = codelist_from_csv(
-    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
+    CODELIST_DIR
+    / "opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
     system="ctv3",
     column="CTV3ID",
 )

--- a/analysis/codelists_ehrql.py
+++ b/analysis/codelists_ehrql.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 from databuilder.codes import REGISTRY, Codelist, codelist_from_csv
+
+CODELIST_DIR = Path("codelists")
 
 
 def codelist(codes, system):
@@ -10,7 +14,7 @@ def codelist(codes, system):
 
 
 covid_icd10 = codelist_from_csv(
-    "codelists/opensafely-covid-identification.csv",
+    CODELIST_DIR / "opensafely-covid-identification.csv",
     system="icd10",
     column="icd10_code",
 )
@@ -21,31 +25,31 @@ covid_emergency = codelist(
 )
 
 covid_primary_care_positive_test = codelist_from_csv(
-    "codelists/opensafely-covid-identification-in-primary-care-probable-covid-positive-test.csv",
+    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-positive-test.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 covid_primary_care_code = codelist_from_csv(
-    "codelists/opensafely-covid-identification-in-primary-care-probable-covid-clinical-code.csv",
+    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-clinical-code.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 covid_primary_care_sequelae = codelist_from_csv(
-    "codelists/opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
+    CODELIST_DIR / "opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
     system="ctv3",
     column="CTV3ID",
 )
 
 ethnicity = codelist_from_csv(
-    "codelists/opensafely-ethnicity.csv",
+    CODELIST_DIR / "opensafely-ethnicity.csv",
     system="ctv3",
     column="Code",
 )
 
 carehome = codelist_from_csv(
-    "codelists/primis-covid19-vacc-uptake-longres.csv",
+    CODELIST_DIR / "primis-covid19-vacc-uptake-longres.csv",
     system="snomedct",
     column="code",
 )

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -24,8 +24,17 @@ from variable_lib import (
 
 # Define list of hospital admission methods
 hospital_admission_methods = [
-    "21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"
-    ]
+    "21",
+    "22",
+    "23",
+    "24",
+    "25",
+    "2A",
+    "2B",
+    "2C",
+    "2D",
+    "28",
+]
 
 # COMBINE CODELISTS
 # Containing primary care covid events
@@ -112,9 +121,7 @@ dataset.covidemergency_01 = (
 dataset.covidadmitted_01 = (
     hospitalisation_diagnosis_matches(hospital_admissions, codelists_ehrql.covid_icd10)
     .take(hospital_admissions.admission_date == index_date)
-    .take(
-        hospital_admissions.admission_method.is_in(hospital_admission_methods)
-    )
+    .take(hospital_admissions.admission_method.is_in(hospital_admission_methods))
     .exists_for_patient()
 )
 
@@ -163,9 +170,7 @@ dataset.covidadmitted_14 = (
         (hospital_admissions.admission_date >= (index_date - timedelta(days=13)))
         & (hospital_admissions.admission_date <= index_date)
     )
-    .take(
-        hospital_admissions.admission_method.is_in(hospital_admission_methods)
-    )
+    .take(hospital_admissions.admission_method.is_in(hospital_admission_methods))
     .exists_for_patient()
 )
 
@@ -205,9 +210,7 @@ dataset.covidemergency_ever = (
 dataset.covidadmitted_ever = (
     hospitalisation_diagnosis_matches(hospital_admissions, codelists_ehrql.covid_icd10)
     .take((hospital_admissions.admission_date <= index_date))
-    .take(
-        hospital_admissions.admission_method.is_in(hospital_admission_methods)
-    )
+    .take(hospital_admissions.admission_method.is_in(hospital_admission_methods))
     .exists_for_patient()
 )
 

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -225,7 +225,7 @@ dataset.any_infection_or_disease_ever = (
 
 has_practice_reg = practice_reg.exists_for_patient()
 has_msoa_not_null = dataset.msoa.is_not_null()
-has_sex_f_or_m = (dataset.sex == "female") | (dataset.sex == "male")
+has_sex_f_or_m = dataset.sex.is_in(["female", "male"])
 has_age_between_2_and_120 = (dataset.age >= 2) & (dataset.age <= 120)
 has_not_died = ~has_died
 has_no_care_home_status = ~(care_home_tpp | care_home_code)

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -53,7 +53,6 @@ dataset = Dataset()
 
 address = address_as_of(index_date)
 prior_events = clinical_events.take(clinical_events.date.is_on_or_before(index_date))
-practice_reg = practice_registration_as_of(index_date)
 prior_tests = sgss_covid_all_tests.take(
     sgss_covid_all_tests.specimen_taken_date.is_on_or_before(index_date)
 )
@@ -75,6 +74,9 @@ care_home_code = has_matching_event(prior_events, codelists_ehrql.carehome)
 
 # Middle Super Output Area (MSOA)
 dataset.msoa = address.msoa_code
+
+# Practice registration
+practice_reg = practice_registration_as_of(index_date)
 
 # STP is an NHS administration region based on geography
 dataset.stp = practice_reg.practice_stp

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -22,6 +22,11 @@ from variable_lib import (
     practice_registration_as_of,
 )
 
+# Define list of hospital admission methods
+hospital_admission_methods = [
+    "21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"
+    ]
+
 # COMBINE CODELISTS
 # contraining primary care covid events
 primary_care_covid_events = clinical_events.take(
@@ -108,9 +113,7 @@ dataset.covidadmitted_01 = (
     hospitalisation_diagnosis_matches(hospital_admissions, codelists_ehrql.covid_icd10)
     .take(hospital_admissions.admission_date == index_date)
     .take(
-        hospital_admissions.admission_method.is_in(
-            ["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"]
-        )
+        hospital_admissions.admission_method.is_in(hospital_admission_methods)
     )
     .exists_for_patient()
 )
@@ -161,9 +164,7 @@ dataset.covidadmitted_14 = (
         & (hospital_admissions.admission_date <= index_date)
     )
     .take(
-        hospital_admissions.admission_method.is_in(
-            ["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"]
-        )
+        hospital_admissions.admission_method.is_in(hospital_admission_methods)
     )
     .exists_for_patient()
 )
@@ -205,9 +206,7 @@ dataset.covidadmitted_ever = (
     hospitalisation_diagnosis_matches(hospital_admissions, codelists_ehrql.covid_icd10)
     .take((hospital_admissions.admission_date <= index_date))
     .take(
-        hospital_admissions.admission_method.is_in(
-            ["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"]
-        )
+        hospital_admissions.admission_method.is_in(hospital_admission_methods)
     )
     .exists_for_patient()
 )

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -68,9 +68,7 @@ dataset.age = age_as_of(index_date)
 has_died = ons_deaths.take(ons_deaths.date <= index_date).exists_for_patient()
 
 # TPP care home flag
-care_home_tpp = case(
-    when(address.care_home_is_potential_match).then(True), default=False
-)
+care_home_tpp = address.care_home_is_potential_match.if_null_then(False)
 
 # Patients in long-stay nursing and residential care
 care_home_code = has_matching_event(prior_events, codelists_ehrql.carehome)

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -131,14 +131,14 @@ dataset.any_infection_or_disease_01 = (
 
 # Positive COVID test
 dataset.postest_14 = prior_tests.take(
-    (prior_tests.specimen_taken_date >= (index_date - timedelta(days=14)))
+    (prior_tests.specimen_taken_date >= (index_date - timedelta(days=13)))
     & (prior_tests.specimen_taken_date <= index_date)
     & (prior_tests.is_positive)
 ).exists_for_patient()
 
 # Positive case identification
 dataset.primary_care_covid_case_14 = primary_care_covid_events.take(
-    (clinical_events.date >= (index_date - timedelta(days=14)))
+    (clinical_events.date >= (index_date - timedelta(days=13)))
     & (clinical_events.date <= index_date)
 ).exists_for_patient()
 
@@ -148,7 +148,7 @@ dataset.covidemergency_14 = (
         emergency_care_attendances, codelists_ehrql.covid_emergency
     )
     .take(
-        (emergency_care_attendances.arrival_date >= (index_date - timedelta(days=14)))
+        (emergency_care_attendances.arrival_date >= (index_date - timedelta(days=13)))
         & (emergency_care_attendances.arrival_date <= index_date)
     )
     .exists_for_patient()
@@ -158,7 +158,7 @@ dataset.covidemergency_14 = (
 dataset.covidadmitted_14 = (
     hospitalisation_diagnosis_matches(hospital_admissions, codelists_ehrql.covid_icd10)
     .take(
-        (hospital_admissions.admission_date >= (index_date - timedelta(days=14)))
+        (hospital_admissions.admission_date >= (index_date - timedelta(days=13)))
         & (hospital_admissions.admission_date <= index_date)
     )
     .take(

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -13,7 +13,7 @@ from databuilder.tables.beta.tpp import (
 
 import codelists_ehrql
 from variable_lib import (
-    has_prior_event,
+    has_matching_event,
     combine_codelists,
     address_as_of,
     age_as_of,
@@ -73,7 +73,7 @@ care_home_tpp = case(
 )
 
 # Patients in long-stay nursing and residential care
-care_home_code = has_prior_event(prior_events, codelists_ehrql.carehome)
+care_home_code = has_matching_event(prior_events, codelists_ehrql.carehome)
 
 # Middle Super Output Area (MSOA)
 dataset.msoa = address.msoa_code

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -28,7 +28,7 @@ hospital_admission_methods = [
     ]
 
 # COMBINE CODELISTS
-# contraining primary care covid events
+# Containing primary care covid events
 primary_care_covid_events = clinical_events.take(
     clinical_events.ctv3_code.is_in(
         combine_codelists(

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -224,24 +224,24 @@ dataset.any_infection_or_disease_ever = (
 # Define dataset restrictions
 ###############################################################################
 
-set_registered = practice_reg.exists_for_patient()
-set_msoa_not_null = dataset.msoa.is_not_null()
-set_sex_fm = (dataset.sex == "female") | (dataset.sex == "male")
-set_age_ge2_le120 = (dataset.age >= 2) & (dataset.age <= 120)
-set_has_not_died = ~has_died
-set_not_care_home = ~(care_home_tpp | care_home_code)
+has_practice_reg = practice_reg.exists_for_patient()
+has_msoa_not_null = dataset.msoa.is_not_null()
+has_sex_f_or_m = (dataset.sex == "female") | (dataset.sex == "male")
+has_age_between_2_and_120 = (dataset.age >= 2) & (dataset.age <= 120)
+has_not_died = ~has_died
+has_no_care_home_status = ~(care_home_tpp | care_home_code)
 
 ###############################################################################
 # Apply dataset restrictions and define study population
 ###############################################################################
 
 dataset.set_population(
-    set_registered
-    & set_sex_fm
-    & set_age_ge2_le120
-    & set_has_not_died
-    & set_not_care_home
-    & set_msoa_not_null
+    has_practice_reg
+    & has_sex_f_or_m
+    & has_age_between_2_and_120
+    & has_not_died
+    & has_no_care_home_status
+    & has_msoa_not_null
 )
 
 
@@ -250,7 +250,7 @@ dataset.set_population(
 new_dataset = Dataset()
 new_dataset.set_population(patients.exists_for_patient())
 
-new_dataset.registered = set_registered
+new_dataset.registered = has_practice_reg
 new_dataset.has_died = has_died
 new_dataset.care_home_tpp = care_home_tpp
 new_dataset.care_home_code = care_home_code

--- a/analysis/variable_lib.py
+++ b/analysis/variable_lib.py
@@ -7,10 +7,10 @@ from databuilder.tables.beta import tpp as schema
 from databuilder.codes import Codelist
 
 
-def has_prior_event(prior_events, codelist, where=True):
+def has_matching_event(events, codelist, where=True):
     return (
-        prior_events.take(where)
-        .take(prior_events.snomedct_code.is_in(codelist))
+        events.take(where)
+        .take(events.snomedct_code.is_in(codelist))
         .exists_for_patient()
     )
 


### PR DESCRIPTION
This PR contains many small commits, each corresponding to a specific code change suggested by @StevenMaude or @evansd. 

Following suggestiongs from @StevenMaude @evansd @sebbacon this improves the prefix of boolean variables used in `.set_population()`. The prefix `is_*` or `has_*` are more commonly used for boolean variables. I decided to use `has_*` consistently across all variables, although `is_*` might fit better for some variables (e.g., `is_registered` or `is_aged_between_2_and_120`).
